### PR TITLE
wrong translation (false friend) for 'silicon'

### DIFF
--- a/page3_de.html
+++ b/page3_de.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 
 <head>
@@ -12,7 +11,7 @@
 
 <p>In der Welt des Computers gibt es nur Daten. Was nicht Daten ist,
 ist nicht. Programme sind Daten. Programmen erschaffen neue Daten. Es
-ist ein eigenartiger, auf Silikon basierender Kreislauf des Lebens.</p>
+ist ein eigenartiger, auf Silicium basierender Kreislauf des Lebens.</p>
 
 
 <h2 class=step>Datenstrukturen</h2>


### PR DESCRIPTION
silicon (engl) = Silicium (german)
silicone (engl) = Silikon (german)
