### PR TITLE
Made 'Named properties' section on page 3 clearer and more accessible

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -121,18 +121,24 @@ stripes a bit bigger.</p>
 
 <p>Open the console again, in case you had closed it.</p>
 
-<p>Create a variable by entering this in the console: <code>var myObject = {name: "Larry", score: 100};</code></p>
+<p>Create a variable named <code>myObject</code> by entering this in the
+  console: <code>var myObject = {name: "Larry", score: 100};</code></p>
 
-<p>Evaluate <code>myObject.name</code> and <code>myObject.score</code>.</p>
+<p>You can now get the value of the <code>name</code> property of
+  <code>myObject</code> by entering <code>myObject.name</code> into the
+  console. You can do the same for the <code>score</code> property by
+  entering <code>myObject.score</code>.</p>
 
-<p>Also evaluate <code>myObject["name"]</code> and <code>myObject["sco" + "re"]</code>.</p>
+<p>Next, enter <code>myObject["name"]</code> into the console, and then
+  <code>myObject["sco" + "re"]</code>.</p>
 
-<p>Give the object another property with <code>myObject.color =
-"purple"</code>. Then evaluate <code>myObject.color</code>.</p>
+<p>Give the object another property by entering <code>myObject.color =
+  "purple"</code>. Then get the value of the newly created <code>color</code>
+  property by entering <code>myObject.color</code>.</p>
 
-<p>Change the <code>score</code> property by doing 
-<code>myObject.score = 105</code>. Evaluate <code>myObject.score</code>
-again to convince yourself that it worked.</p>
+<p>Change the <code>score</code> property by entering
+  <code>myObject.score = 105</code>. Then check that you successfully changed the
+  value by entering <code>myObject.score</code>.</p>
 
 <h3 class=ex>Explanation</h3>
 


### PR DESCRIPTION
Made 'Named properties' section on page 3 clearer and more accessible, as requested in issue #11.
