### PR TITLE
update description how to switch the frame in the console

### DIFF
--- a/page1.html
+++ b/page1.html
@@ -210,10 +210,11 @@ function.</p>
 sandbox, you have to take an extra step. If you open a console on that
 tab, and you type <code>myMessage</code> into it, it won't find that
 variable. This is because the console is connected to the sandbox page
-itself, not the page shown inside of it. At the bottom of the console,
-there is a control that says <code>&lt;top frame></code>. Click on
-this and select the other option to connect the console to the actual
-page we wrote.</p>
+itself, not the page shown inside of it. At the top left of the console,
+there is a control that says <code>&lt;top></code>. Click on
+this and select the option with the name of the domain that is
+shown in the address bar of the browser to connect the console to the
+actual page we wrote.</p>
 
 <p>The button in the example page has a snippet of JavaScript
 associated with it through an <code>onclick</code> attribute.

--- a/page1_de.html
+++ b/page1_de.html
@@ -223,11 +223,12 @@ alert(meinwert);</pre>
   Sandkasten angezeigt wird, ist ein zusätzlicher Schritt nötig.
   Wenn Du die Konsole in diesem Tab öffnest und <code>myMessage</code>
   eintippst, wird es die Variable nicht finden. Der Grund ist, dass
-  die Konsole mit der Sandkasten-Seite selbst verbunden ist—nicht
-  mit der Seite, die darin angezeigt wird. Am unteren Ende der Konsole
-  gibt es eine Schaltfäche auf der <code>&lt;top frame></code> steht.
-  Klicke sie an und wähle die andere Option aus, um die Konsole mit der
-  Seite zu verbinden, die wir geschrieben haben.</p>
+  die Konsole mit der Sandkasten-Seite selbst verbunden ist, nicht
+  mit der Seite, die darin angezeigt wird. Oben links in der Konsole
+  gibt es eine Schaltfäche auf der <code>&lt;top></code> steht.
+  Klicke sie an und wähle die Option mit dem Namen der Domain in der
+  Adressleiste im Browser um die Konsole mit der Seite zu verbinden,
+  die wir geschrieben haben.</p>
 
 <p>Der Button auf der Beispielseite ist über sein
   <code>onclick</code>-Attribut mit einem Stück JavaScript-Code


### PR DESCRIPTION
the position and label of the switch changed in chrome. this updates that. also trying to be more specific.

improving but not fully fixing https://github.com/OpenTechSchool/js-beginners-1/issues/21
