### PR TITLE
Remove "day 1" / "part 1" to make this stand on its own - fixes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Curriculum for the first part of the OpenTechSchool workshop "JavaScript for absolute beginners".
+Curriculum for the OpenTechSchool workshop "JavaScript for absolute beginners".
 
 It's mainly about basics of the JavaScript programming language.

--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 <!doctype html>
 
 <head>
-  <title>Curriculum — JS for absolute beginners</title>
+  <title>Curriculum — JavaScript for absolute beginners</title>
   <link rel=stylesheet href="fonts.googleapis.com/css-family=Averia+Serif+Libre:300,400">
   <link rel=stylesheet href=style.css>
   <meta http-equiv=Content-Type content="text/html; charset=utf-8">
 </head>
 
-<h1>Curriculum: first day</h1>
+<h1>Curriculum: JavaScript for absolute beginners</h1>
 
 <p><a href="index_de.html">Auf Deutsch »</a></p>
 
-<p>On the first day, our goal is to learn enough JavaScript to be
+<p>The goal of this workshop is to learn enough JavaScript to be
 dangerous, and to get a good feel for the natural habitat (web,
 browser, HTML) of JavaScript programs.</p>
 

--- a/index_de.html
+++ b/index_de.html
@@ -1,15 +1,15 @@
 <!doctype html>
 
 <head>
-  <title>Kursmaterial — JS für absolute Beginner</title>
+  <title>Kursmaterial — JavaScript für absolute Beginner</title>
   <link rel=stylesheet href="fonts.googleapis.com/css-family=Averia+Serif+Libre:300,400">
   <link rel=stylesheet href=style.css>
   <meta http-equiv=Content-Type content="text/html; charset=utf-8">
 </head>
 
-<h1>Kursmaterial: Erster Tag</h1>
+<h1>Kursmaterial: JavaScript für absolute Beginner</h1>
 
-<p>Unser Ziel für den ersten Tag ist es, genug JavaScript zu lernen
+<p>Unser Ziel für diesen Workshop ist es, genug JavaScript zu lernen
 um gefährlich zu sein und nebenbei ein Gefühl für JavaScripts natürlichen
 Lebensraum (Web, Browser, HTML) zu bekommen.</p>
 

--- a/page3.html
+++ b/page3.html
@@ -258,4 +258,4 @@ days to the dataset. You can use data you acquire from
 
 <h3>And so we reach</h3>
 
-<p><a href="page4.html">→ The final page of the day</a>.</p>
+<p><a href="page4.html">→ The last page</a>.</p>

--- a/page3_de.html
+++ b/page3_de.html
@@ -261,6 +261,6 @@ function drawing() {
 <p>Um zu schauen ob deine Funktion so arbeitet wie du es erwartest, füge ein paar zusätzliche Tage
 zu dem Datensatz hinzu. Du kannst welche <a href="http://de.weather.com" target="_blank">im Netz</a> finden.</p>
 
-<h3>Und damit kommen wir zu</h3>
+<h3>Und damit kommen wir…</h3>
 
-<p><a href="page4_de.html">→ Vierte und letzte Seite für Samstag</a>.</p>
+<p><a href="page4_de.html">→ …zur letzte Seite</a>.</p>


### PR DESCRIPTION
Historically this has been part 1 of a two-day workshop with the second part being a slide show with DOM. The "second" part is quite outdated (e.g. JS animations) and this should just stand on it's own so some text needs to be changed.