### PR TITLE
Update instructions how to open the console #32

### DIFF
--- a/page1.html
+++ b/page1.html
@@ -25,13 +25,12 @@ fundamental programming.</p>
 Command+Option+J on OS X. (Hold down the first two keys, then press J.
 On German keyboards, Ctrl is labeled Strg.)</p>
 
-<p>You can also go to the wrench menu in the upper right corner of
-your window, and select <code>Tools</code> ▸ <code>JavaScript
-Console</code>.</p>
+<p>You can also go to the Chrome's main menu in the upper right corner of
+your window, and select <code>More Tools</code> ▸ <code>Developer Tools</code>.</p>
 
-<p>The console window should appear at the bottom of your browser window.</p>
+<p>The console window should appear at the right side of your browser window.</p>
 
-<p>Resize it by dragging its top border.</p>
+<p>Resize it by dragging its left border.</p>
 
 <p>Click through the icons along the top, and enjoy the awesomely
 complicated-looking graphs and tech-garble. This
@@ -58,7 +57,7 @@ you need will be explained as we go on.</p>
 
 <h3 class=inst>Instructions</h3>
 
-<p>Go to the 'Console' (rightmost) tab in the browser console.</p>
+<p>Go to the 'Console' tab in the browser console.</p>
 
 <p>Type random junk next to the <strong>></strong> sign and press enter.</p>
 


### PR DESCRIPTION
Updated the instructions to reflect the Chrome devtools UI changes. Tested on gnu/Linux running Chrome 61 