### PR TITLE
chore: typo

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -10,7 +10,7 @@
 
 <p>This is a document. The text in angle brackets (tags) provides meta
 information about its structure. P stands for paragraph, for example.
-When preceded by a slash, the it ends the tag.</p>
+When preceded by a slash, it ends the tag.</p>
 
 <p>Here is a button that runs some JavaScript when
 clicked: <button onclick="alert(myMessage);">Click me</button></p>


### PR DESCRIPTION
remove unnecessary word