### PR TITLE
Remove unused, unexplained parameters from smileySquadron

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -245,8 +245,7 @@ whichever variable happens to be called <code>x</code> in that
 function.</p>
 
 <p><strong>Exercise:</strong> define a
-function <code>smileySquadron</code>, which, given <code>x</code>
-and <code>y</code> parameters, draws five or so smileys next to each
+function <code>smileySquadron</code> draws five smileys next to each
 other by using a <code>while</code> loop. Once it works, use it to
 draw a whole lot of smileys.</p>
 

--- a/page2_de.html
+++ b/page2_de.html
@@ -279,8 +279,7 @@ while (count < 20) {
   existiert.</p>
 
 <p><strong>Übung:</strong> Definiere eine Funktion
-  <code>smileySquadron</code>, die zwei Parameter nimmt (<code>x</code>
-  und <code>y</code>) und fünf Smileys oder so nebeneinander malt.
+  <code>smileySquadron</code> die fünf Smileys nebeneinander malt.
   Verwende dafür eine <code>while</code>-Schleife.
   Und wenn das funktioniert, male so viele Smileys wie Du möchtest!</p>
 


### PR DESCRIPTION
fixes #20 

the parameters are confusing, not needed and lead to `Uncaught ReferenceError: x is not defined`.